### PR TITLE
ci: update `actions/checkout` from v2 to v3 in our GitHub workflows

### DIFF
--- a/.github/workflows/storage-image-processing-api.yaml
+++ b/.github/workflows/storage-image-processing-api.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,7 +7,7 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2-beta
         with:
           node-version: '14'


### PR DESCRIPTION
Node 12 is deprecated for GitHub Actions. This is the reason why we are getting a warning from GitHub:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

This PR updates `actions/checkout` from v2 to v3 which should fix the problem.