### PR TITLE
fix(image-processing-api): downgrade high risk role

### DIFF
--- a/extensions/image-processing-api/CHANGELOG.md
+++ b/extensions/image-processing-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.2
+
+fix - downgrade to storage.objectAdmin role
+
 ## Version 0.2.1
 
 feat - add hostname param

--- a/extensions/image-processing-api/extension.yaml
+++ b/extensions/image-processing-api/extension.yaml
@@ -1,5 +1,5 @@
 name: image-processing-api
-version: 0.2.1
+version: 0.2.2
 specVersion: v1beta
 
 displayName: Image Processing API
@@ -27,7 +27,7 @@ apis:
     reason: Needed to use Cloud Storage
 
 roles:
-  - role: storage.admin
+  - role: storage.objectAdmin
     reason: Allows the extension to read images in Cloud Storage
 
 resources:


### PR DESCRIPTION
This PR downgrades image-processing-api requested role to storage.objectAdmin, for better security.